### PR TITLE
Fix broken link to blacklist database

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Untuk yang ingin request, silahkan untuk open issue [disini](https://github.com/
 Sebelum menggunakan aplikasi ini, Anda wajib mematuhi peraturan yang kami buat, dengan menggunakan aplikasi ini Anda berarti menerima segala akibat yang ditimbulkan. Lihat [RULES](https://github.com/gvoze32/bebasid/blob/master/RULES.md).
 
 # Database
-Database pemblokiran oleh Kominfo bisa didownload [disini](https://trustpositif.kominfo.go.id/files/downloads/database/blacklist/pengaduan/domains)
+Database pemblokiran oleh Kominfo bisa didownload [disini](https://trustpositif.kominfo.go.id/files/downloads/database/blacklist/pengaduan/domains.txt)


### PR DESCRIPTION
The file has been moved from `domain` to `domain.txt`.